### PR TITLE
bug with function lamdba clean, which modifies column names on read-in to be valid python names

### DIFF
--- a/atpy/basetable.py
+++ b/atpy/basetable.py
@@ -193,7 +193,7 @@ class Table(object):
         elif type(args[0]) == str:
             table_type = atpy._determine_type(args[0], verbose)
         else:
-            raise Exception('Could not determine input type')
+            raise Exception('Could not determine file type')
 
         original_filters = warnings.filters[:]
 
@@ -244,7 +244,7 @@ class Table(object):
         elif type(args[0]) == str:
             table_type = atpy._determine_type(args[0], verbose)
         else:
-            raise Exception('Could not determine input type')
+            raise Exception('Could not determine file type')
 
         original_filters = warnings.filters[:]
 
@@ -976,7 +976,7 @@ class TableSet(object):
         elif type(args[0]) == str:
             table_type = atpy._determine_type(args[0], verbose)
         else:
-            raise Exception('Could not determine input type')
+            raise Exception('Could not determine file type')
 
         original_filters = warnings.filters[:]
 
@@ -1027,7 +1027,7 @@ class TableSet(object):
         elif type(args[0]) == str:
             table_type = atpy._determine_type(args[0], verbose)
         else:
-            raise Exception('Could not determine input type')
+            raise Exception('Could not determine file type')
 
         original_filters = warnings.filters[:]
 


### PR DESCRIPTION
Hi,

I had a problem reading a table with a column name `B-V`. The new automatic cleaning changed that name into `B_V`, but than could not access the data in the structure it read, because there it is still called `['B-V]'`.
This sounds a little confusing in this post, but it is pretty obvious when you check in the code, where I made the change.

Moritz
