### PR TITLE
atpy inserting 2d columns in SQL tables

### DIFF
--- a/atpy/sqlhelper.py
+++ b/atpy/sqlhelper.py
@@ -79,6 +79,7 @@ type_dict[np.float64] = "DOUBLE PRECISION"
 type_dict[np.str] = "TEXT"
 type_dict[np.string_] = "TEXT"
 type_dict[str] = "TEXT"
+type_dict[np.bool_] = "BOOLEAN"
 
 # Reverse type conversion dictionary
 
@@ -115,7 +116,7 @@ type_dict_rev['blob'] = np.str
 type_dict_rev['timestamp'] = np.str
 type_dict_rev['date'] = np.str
 type_dict_rev['var_string'] = np.str
-
+type_dict_rev['boolean'] = np.bool
 
 # Define symbol to use in insert statement
 


### PR DESCRIPTION
Hi, 

I've implemented a simple way of inserting atpy tables with 2-D columns into SQL tables, by treating 2-D columns as multiple columns with _1, _2 added to their name ( a bit like explodeall command in java stilts library). 

The code seems to work for me. It would be nice if you could acccept my patch into upstream ATpy

```
Sergey 
```
