### PR TITLE
Switch to using Astropy

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 CHANGES
 --------
 
+Version 0.9.7
+
+    The main change in this version is that Astropy is now required as a
+    dependency, and PyFITS, vo, and asciitable are no longer required.
+
 Version 0.9.6
 
     New Features

--- a/atpy/asciitables.py
+++ b/atpy/asciitables.py
@@ -2,20 +2,11 @@ from __future__ import print_function, division
 
 import os
 
+from astropy.io import ascii as asciitable
+
 from .decorators import auto_download_to_file, auto_decompress_to_fileobj
 
 # Thanks to Moritz Guenther for providing the initial code used to create this file
-
-try:
-    import asciitable
-    asciitable_installed = True
-except:
-    asciitable_installed = False
-
-
-def _check_asciitable_installed():
-    if not asciitable_installed:
-        raise Exception("Cannot read data with asciitable - no version of asciitable is found")
 
 
 def read_cds(self, filename, **kwargs):
@@ -131,8 +122,6 @@ def read_ascii(self, filename, **kwargs):
     See the asciitable documentation at http://cxc.harvard.edu/contrib/asciitable/ for more details.
     '''
 
-    _check_asciitable_installed()
-
     self.reset()
 
     kwargs['numpy'] = True
@@ -161,8 +150,6 @@ def write_ascii(self, filename, **kwargs):
 
     See the asciitable documentation at http://cxc.harvard.edu/contrib/asciitable/ for more details.
     '''
-
-    _check_asciitable_installed()
 
     if 'overwrite' in kwargs:
         overwrite = kwargs.pop('overwrite')

--- a/atpy/basetable.py
+++ b/atpy/basetable.py
@@ -561,9 +561,9 @@ class Table(object):
             dtype = data.dtype
 
         if data.ndim > 1:
-            newdtype = (name, data.dtype, (data.shape[1],))
+            newdtype = (str(name), data.dtype, (data.shape[1],))
         else:
-            newdtype = (name, data.dtype)
+            newdtype = (str(name), data.dtype)
 
         if before:
             try:

--- a/atpy/votable.py
+++ b/atpy/votable.py
@@ -5,25 +5,14 @@ from distutils import version
 import numpy as np
 import warnings
 
+from astropy.io.vo.table import parse
+from astropy.io.vo.tree import VOTableFile, Resource, Field, Param
+from astropy.io.vo.tree import Table as VOTable
+
 from .exceptions import TableException
 from .helpers import smart_dtype
 from .decorators import auto_download_to_file, auto_decompress_to_fileobj, auto_fileobj_to_file
 
-vo_minimum_version = version.LooseVersion('0.3')
-
-try:
-    from vo.table import parse
-    from vo.tree import VOTableFile, Resource, Field, Param
-    from vo.tree import Table as VOTable
-    vo_installed = True
-except:
-    vo_installed = False
-
-
-def _check_vo_installed():
-    if not vo_installed:
-        raise Exception("Cannot read/write VO table files - vo " +  \
-            vo_minimum_version.vstring + " or later required")
 
 # Define type conversion dictionary
 type_dict = {}
@@ -73,8 +62,6 @@ def read(self, filename, pedantic=False, tid=-1, verbose=True):
             When *pedantic* is True, raise an error when the file violates
             the VO Table specification, otherwise issue a warning.
     '''
-
-    _check_vo_installed()
 
     self.reset()
 
@@ -247,7 +234,6 @@ def write(self, filename, votype='ascii', overwrite=False):
             Whether to write the table as ASCII or binary
     '''
 
-    _check_vo_installed()
 
     if os.path.exists(filename):
         if overwrite:
@@ -289,7 +275,6 @@ def read_set(self, filename, pedantic=False, verbose=True):
             the VO Table specification, otherwise issue a warning.
     '''
 
-    _check_vo_installed()
 
     self.reset()
 
@@ -315,7 +300,6 @@ def write_set(self, filename, votype='ascii', overwrite=False):
             Whether to write the tables as ASCII or binary tables
     '''
 
-    _check_vo_installed()
 
     if os.path.exists(filename):
         if overwrite:


### PR DESCRIPTION
Switch from PyFITS/asciitable/vo to Astropy. Astropy is now required rather than optional, which simplifies a lot of code. Note that in future, we will switch to using the base table class and I/O registration in Astropy itself, but for now, this simplifies dependencies.
